### PR TITLE
Uptate condition in c3.php

### DIFF
--- a/c3.php
+++ b/c3.php
@@ -43,10 +43,10 @@ if (!function_exists('__c3_error')) {
 
 // Autoload Codeception classes
 if (!class_exists('\\Codeception\\Codecept')) {
-    if (stream_resolve_include_path(__DIR__ . '/vendor/autoload.php')) {
-        require_once __DIR__ . '/vendor/autoload.php';
-    } elseif (file_exists(__DIR__ . '/codecept.phar')) {
+    if (file_exists(__DIR__ . '/codecept.phar')) {
         require_once 'phar://'.__DIR__ . '/codecept.phar/autoload.php';
+    } elseif (stream_resolve_include_path(__DIR__ . '/vendor/autoload.php')) {
+        require_once __DIR__ . '/vendor/autoload.php';
     } elseif (stream_resolve_include_path('Codeception/autoload.php')) {
         require_once 'Codeception/autoload.php';
     } else {


### PR DESCRIPTION
I think that you need to change the condition of the autoload.
If you are working with codecept.phar and you also have composer for other purposes (ie: SF2 framework), you are getting a error because the \codeception\configuration class is not loaded.

kind regards.