### PR TITLE
Solution for Undefined variable C3_CODECOVERAGE_MEDIATE_STORAGE in __c3_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Example file: `web/index.php`:
 ``` php
 <?php
 
+define('C3_CODECOVERAGE_ERROR_LOG_FILE', '/path/to/c3_error.log'); //Optional (if not set the default c3 output dir will be used)
 include '/../c3.php';
 
 define('MY_APP_STARTED', true);

--- a/c3.php
+++ b/c3.php
@@ -33,7 +33,14 @@ if (!array_key_exists('HTTP_X_CODECEPTION_CODECOVERAGE', $_SERVER)) {
 if (!function_exists('__c3_error')) {
     function __c3_error($message)
     {
-        file_put_contents(C3_CODECOVERAGE_MEDIATE_STORAGE . DIRECTORY_SEPARATOR . 'error.txt', $message);
+        $errorLogFile = defined('C3_CODECOVERAGE_ERROR_LOG_FILE') ?
+            C3_CODECOVERAGE_ERROR_LOG_FILE :
+            C3_CODECOVERAGE_MEDIATE_STORAGE . DIRECTORY_SEPARATOR . 'error.txt';
+        if (is_writable($errorLogFile)) {
+            file_put_contents($errorLogFile, $message);
+        }else{
+            $message = "Could not write error to log file ($errorLogFile), original message: $message";
+        }
         if (!headers_sent()) {
             header('X-Codeception-CodeCoverage-Error: ' . str_replace("\n", ' ', $message), true, 500);
         }


### PR DESCRIPTION
When an error occurs before ```C3_CODECOVERAGE_MEDIATE_STORAGE``` is set it is not logged to any file nor is it returned via the header.

This patch provides an additional constant ```C3_CODECOVERAGE_ERROR_LOG_FILE``` which can be set before including the c3.php file:

```
define('C3_CODECOVERAGE_ERROR_LOG_FILE', '/path/to/c3_error.log');
require_once('/path/to//c3.php');
```

Related issues:
Codeception/Codeception#1495
lordlele/codeception-test#1