### PR TITLE
Allow c3 to use codeception.dist.yml

### DIFF
--- a/c3.php
+++ b/c3.php
@@ -55,11 +55,15 @@ if (!class_exists('\\Codeception\\Codecept')) {
 }
 
 // Load Codeception Config
+$config_dist_file = realpath(__DIR__) . DIRECTORY_SEPARATOR . 'codeception.dist.yml';
 $config_file = realpath(__DIR__) . DIRECTORY_SEPARATOR . 'codeception.yml';
 if (isset($_SERVER['HTTP_X_CODECEPTION_CODECOVERAGE_CONFIG'])) {
     $config_file = realpath(__DIR__) . DIRECTORY_SEPARATOR . $_SERVER['HTTP_X_CODECEPTION_CODECOVERAGE_CONFIG'];
 }
-if (!file_exists($config_file)) {
+if (!file_exists($config_file) && file_exists($config_dist_file)) {
+    // Use codeception.dist.yml for configuration.
+    $config_file = $config_dist_file;
+} else {
     __c3_error(sprintf("Codeception config file '%s' not found", $config_file));
 }
 try {

--- a/c3.php
+++ b/c3.php
@@ -57,10 +57,13 @@ if (!class_exists('\\Codeception\\Codecept')) {
 // Load Codeception Config
 $config_dist_file = realpath(__DIR__) . DIRECTORY_SEPARATOR . 'codeception.dist.yml';
 $config_file = realpath(__DIR__) . DIRECTORY_SEPARATOR . 'codeception.yml';
+
 if (isset($_SERVER['HTTP_X_CODECEPTION_CODECOVERAGE_CONFIG'])) {
     $config_file = realpath(__DIR__) . DIRECTORY_SEPARATOR . $_SERVER['HTTP_X_CODECEPTION_CODECOVERAGE_CONFIG'];
 }
-if (!file_exists($config_file) && file_exists($config_dist_file)) {
+if (file_exists($config_file)) {
+    // Use codeception.yml for configuration.
+} elseif (file_exists($config_dist_file)) {
     // Use codeception.dist.yml for configuration.
     $config_file = $config_dist_file;
 } else {


### PR DESCRIPTION
c3 does not check for `codeception.dist.yml` if `codeception.yml` does not exist.

This patch checks for `codeception.dist.yml`.