### PR TITLE
Add a .mailmap to consolidate Davert's commits

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,5 @@
+Michael Bodnarchuk "Davert" <davert.php@resend.cc> <davert.php@resend.cc>
+Michael Bodnarchuk "Davert" <davert.php@resend.cc> <davert@mail.ua>
+Michael Bodnarchuk "Davert" <davert.php@resend.cc> <davert@ukr.net>
+Michael Bodnarchuk "Davert" <davert.php@resend.cc> <DavertMik@users.noreply.github.com>
+Michael Bodnarchuk "Davert" <davert.php@resend.cc> <davert.githole@mailican.com>


### PR DESCRIPTION
@DavertMik used various git author configuration when committing in this repo. This patch adds a [`.mailmap` file](https://git-scm.com/docs/git-shortlog#_mapping_authors) to consolidate credits.

Check result with `git shortlog -e`