### PR TITLE
Check if file has changed in the installer

### DIFF
--- a/Installer.php
+++ b/Installer.php
@@ -6,6 +6,15 @@ class Installer
 {
     public static function copyC3ToRoot(Event $event) {
         $io = $event->getIO();
+        
+        if (
+            file_exists(getcwd().DIRECTORY_SEPARATOR.'c3.php') &&
+            md5_file(__DIR__.DIRECTORY_SEPARATOR.'c3.php') === md5_file(getcwd().DIRECTORY_SEPARATOR.'c3.php')
+        ) {
+            $io->write("<info>[c3]</info> c3.php is already up-to-date");
+            return;
+        }
+
         $io->write("<info>[c3]</info> Copying c3.php to the root of your project...");
         copy(__DIR__.DIRECTORY_SEPARATOR.'c3.php', getcwd().DIRECTORY_SEPARATOR.'c3.php');
         $io->write("<info>[c3]</info> Include c3.php into index.php in order to collect codecoverage from server scripts");


### PR DESCRIPTION
Each time `composer update` is run, c3.php is copied and the developer is told to do something, which can be confusing.
Adding a check to see if the file has changed and actually needs to be copied solves this.