### PR TITLE
Avoid read/write collisions #2

### DIFF
--- a/c3.php
+++ b/c3.php
@@ -19,7 +19,7 @@ if (isset($_COOKIE['CODECEPTION_CODECOVERAGE'])) {
         $cookie = json_decode($cookie, true);
     }
 
-    if ($cookie) {    
+    if ($cookie) {
         foreach ($cookie as $key => $value) {
             $_SERVER["HTTP_X_CODECEPTION_" . strtoupper($key)] = $value;
         }
@@ -50,12 +50,12 @@ if (!function_exists('__c3_error')) {
 
 // phpunit codecoverage shimming
 if (class_exists('SebastianBergmann\CodeCoverage\CodeCoverage')) {
-      class_alias('SebastianBergmann\CodeCoverage\CodeCoverage', 'PHP_CodeCoverage');
-      class_alias('SebastianBergmann\CodeCoverage\Report\Text', 'PHP_CodeCoverage_Report_Text');
-      class_alias('SebastianBergmann\CodeCoverage\Report\PHP', 'PHP_CodeCoverage_Report_PHP');
-      class_alias('SebastianBergmann\CodeCoverage\Report\Clover', 'PHP_CodeCoverage_Report_Clover');
-      class_alias('SebastianBergmann\CodeCoverage\Report\Html\Facade', 'PHP_CodeCoverage_Report_HTML');
-      class_alias('SebastianBergmann\CodeCoverage\Exception', 'PHP_CodeCoverage_Exception');
+    class_alias('SebastianBergmann\CodeCoverage\CodeCoverage', 'PHP_CodeCoverage');
+    class_alias('SebastianBergmann\CodeCoverage\Report\Text', 'PHP_CodeCoverage_Report_Text');
+    class_alias('SebastianBergmann\CodeCoverage\Report\PHP', 'PHP_CodeCoverage_Report_PHP');
+    class_alias('SebastianBergmann\CodeCoverage\Report\Clover', 'PHP_CodeCoverage_Report_Clover');
+    class_alias('SebastianBergmann\CodeCoverage\Report\Html\Facade', 'PHP_CodeCoverage_Report_HTML');
+    class_alias('SebastianBergmann\CodeCoverage\Exception', 'PHP_CodeCoverage_Exception');
 }
 
 // Autoload Codeception classes
@@ -164,14 +164,26 @@ if (!defined('C3_CODECOVERAGE_MEDIATE_STORAGE')) {
 
     /**
      * @param $filename
-     * @return null|PHP_CodeCoverage|\SebastianBergmann\CodeCoverage\CodeCoverage
+     * @param bool $lock Lock the file for writing?
+     * @return [null|PHP_CodeCoverage|\SebastianBergmann\CodeCoverage\CodeCoverage, resource]
      */
-    function __c3_factory($filename)
+    function __c3_factory($filename, $lock=false)
     {
-        $phpCoverage = is_readable($filename)
-            ? unserialize(file_get_contents($filename))
-            : new PHP_CodeCoverage();
-
+        $file = null;
+        if ($filename !== null && is_readable($filename)) {
+            if ($lock) {
+                $file = fopen($filename, 'r+');
+                if (flock($file, LOCK_EX)) {
+                    $phpCoverage = unserialize(stream_get_contents($file));
+                } else {
+                    __c3_error("Failed to acquire write-lock for $filename");
+                }
+            } else {
+                $phpCoverage = unserialize(file_get_contents($filename));
+            }
+        } else {
+            $phpCoverage = new PHP_CodeCoverage();
+        }
 
         if (isset($_SERVER['HTTP_X_CODECEPTION_CODECOVERAGE_SUITE'])) {
             $suite = $_SERVER['HTTP_X_CODECEPTION_CODECOVERAGE_SUITE'];
@@ -192,7 +204,7 @@ if (!defined('C3_CODECOVERAGE_MEDIATE_STORAGE')) {
             __c3_error($e->getMessage());
         }
 
-        return $phpCoverage;
+        return array($phpCoverage, $file);
     }
 
     function __c3_exit()
@@ -220,7 +232,7 @@ $path = realpath(C3_CODECOVERAGE_MEDIATE_STORAGE) . DIRECTORY_SEPARATOR . 'codec
 
 $requested_c3_report = (strpos($_SERVER['REQUEST_URI'], 'c3/report') !== false);
 
-$current_report = $path . '-' . uniqid(microtime(true), true) . '.serialized';
+$complete_report = $current_report = $path . '.serialized';
 if ($requested_c3_report) {
     set_time_limit(0);
 
@@ -231,20 +243,7 @@ if ($requested_c3_report) {
         return __c3_exit();
     }
 
-    if (!file_exists(dirname($path))) {
-        __c3_error("Can't read CodeCoverage reports from ".dirname($path));
-    }
-
-    foreach (scandir(dirname($path)) as $item) {
-        if (strpos($item, 'codecoverage-') === 0) {
-            $filename = dirname($path) . DIRECTORY_SEPARATOR . $item;
-            if (!isset($codeCoverage)) {
-                $codeCoverage = __c3_factory($filename);
-            } else {
-                $codeCoverage->merge(unserialize(file_get_contents($filename)));
-            }
-        }
-    }
+    list($codeCoverage, ) = __c3_factory($complete_report);
 
     switch ($route) {
         case 'html':
@@ -263,8 +262,6 @@ if ($requested_c3_report) {
             return __c3_exit();
         case 'serialized':
             try {
-                $complete_report = $path . '.serialized';
-                file_put_contents($complete_report, serialize($codeCoverage));
                 __c3_send_file($complete_report);
             } catch (Exception $e) {
                 __c3_error($e->getMessage());
@@ -273,9 +270,9 @@ if ($requested_c3_report) {
     }
 
 } else {
-    $codeCoverage = __c3_factory($current_report);
+    list($codeCoverage, ) = __c3_factory(null);
     $codeCoverage->start(C3_CODECOVERAGE_TESTNAME);
-    if (!array_key_exists('HTTP_X_CODECEPTION_CODECOVERAGE_DEBUG', $_SERVER)) { 
+    if (!array_key_exists('HTTP_X_CODECEPTION_CODECOVERAGE_DEBUG', $_SERVER)) {
         register_shutdown_function(
             function () use ($codeCoverage, $current_report) {
 
@@ -286,7 +283,31 @@ if ($requested_c3_report) {
                     }
                 }
 
-                file_put_contents($current_report, serialize($codeCoverage));
+                // This will either lock the existing report for writing and return it along with a file pointer,
+                // or return a fresh PHP_CodeCoverage object without a file pointer. We'll merge the current request
+                // into that coverage object, write it to disk, and release the lock. By doing this in the end of
+                // the request, we avoid this scenario, where Request 2 overwrites the changes from Request 1:
+                //
+                //             Time ->
+                // Request 1 [ <read>               <write>          ]
+                // Request 2 [         <read>                <write> ]
+                //
+                // In addition, by locking the file for exclusive writing, we make sure no other request try to
+                // read/write to the file at the same time as this request (leading to a corrupt file). flock() is a
+                // blocking call, so it waits until an exclusive lock can be acquired before continuing.
+
+                list($existingCodeCoverage, $file) = __c3_factory($current_report, true);
+                $existingCodeCoverage->merge($codeCoverage);
+
+                if ($file === null) {
+                    file_put_contents($current_report, serialize($existingCodeCoverage), LOCK_EX);
+                } else {
+                    fseek($file, 0);
+                    fwrite($file, serialize($existingCodeCoverage));
+                    fflush($file);
+                    flock($file, LOCK_UN);
+                    fclose($file);
+                }
             }
         );
     }


### PR DESCRIPTION
See #24 as well.

This solves the problem described in #24 using an entirely different method (by saving a .serialized file for each request and then merging them later, come report processing). This solves a problem with #24 (as that one prevents requests from being processed in parallel, and thus prevents me from running long-running scripts that are expected to run at the same time as other requests). Sadly, it introduces another problem, as it forces you to collect the report from c3.php instead of Codeception being able to do it locally (which it does by default).
