### PR TITLE
speedup initialization

### DIFF
--- a/c3.php
+++ b/c3.php
@@ -181,6 +181,8 @@ if (!defined('C3_CODECOVERAGE_MEDIATE_STORAGE')) {
             } else {
                 $phpCoverage = unserialize(file_get_contents($filename));
             }
+            
+            return array($phpCoverage, $file);
         } else {
             $phpCoverage = new PHP_CodeCoverage();
         }


### PR DESCRIPTION
When the coverage object is used from cache we do not need to add the config again.

We have over 3000 files it takes ~18sec to collect the file list. So this speed up the coverage run a lot.