### PR TITLE
Fixed issue when trailing slash is enforced in URLs

### DIFF
--- a/c3.php
+++ b/c3.php
@@ -283,7 +283,7 @@ $complete_report = $current_report = $path . '.serialized';
 if ($requested_c3_report) {
     set_time_limit(0);
 
-    $route = ltrim(strrchr($_SERVER['REQUEST_URI'], '/'), '/');
+    $route = ltrim(strrchr(rtrim($_SERVER['REQUEST_URI'], '/'), '/'), '/');
 
     if ($route === 'clear') {
         __c3_clear();


### PR DESCRIPTION
If a trailing slash is enforced for each URL (e.g. via `.htaccess`), then the reports cannot be accessed because the last part comes out as an empty string. To better illustrate the problem, an URL to clear the reports is:

`.../c3/report/clear`

But, it gets changed by the webserver to:

`.../c3/report/clear/`

...so, in this case, the last part after the `/` (`$route`) is actually an empty string.