### PR TITLE
[Travis] Remove useless env entry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: php
 
-env:
-  CODECEPTION_VERSION: '^2.4'
-
 php:
   - 5.6
   - 7.0


### PR DESCRIPTION
As far as I can tell from traits logs, Codeception version 3 is installed, so this env seems useless