### PR TITLE
[Travis] Unlimited memory for composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ php:
   - 7.4
 
 before_script:
+  - export COMPOSER_MEMORY_LIMIT=-1
   - composer require codeception/codeception:"$CODECEPTION_VERSION" --dev --prefer-source
   - if [ "^3.0" != "$CODECEPTION_VERSION" ]; then composer require codeception/module-filesystem codeception/module-cli codeception/module-asserts codeception/module-phpbrowser --dev; fi;
   - cp c3.php vendor/codeception/codeception/tests/data/claypit


### PR DESCRIPTION
Composer runs out of memory on PHP 5.6: https://travis-ci.org/Codeception/c3/jobs/650883966

PHP Fatal error:  Allowed memory size of 1610612736 bytes exhausted (tried to allocate 268435456 bytes) in phar:///home/travis/.phpenv/versions/5.6.40/bin/composer/src/Composer/DependencyResolver/Solver.php on line 223