### PR TITLE
Don't set empty headers, because null values can cause issues

### DIFF
--- a/c3.php
+++ b/c3.php
@@ -24,7 +24,9 @@ if (isset($_COOKIE['CODECEPTION_CODECOVERAGE'])) {
 
     if ($cookie) {
         foreach ($cookie as $key => $value) {
-            $_SERVER["HTTP_X_CODECEPTION_" . strtoupper($key)] = $value;
+            if (!empty($value)) {
+                $_SERVER["HTTP_X_CODECEPTION_" . strtoupper($key)] = $value;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes `<b>Fatal error</b>:  Uncaught Laminas\Diactoros\Exception\InvalidArgumentException: Invalid header value type; must be a string or numeric; received NULL in /srv/www/vendor/laminas/laminas-diactoros/src/HeaderSecurity.php:140`

reported at https://github.com/Codeception/c3/issues/67#issuecomment-838312744
