### PR TITLE
Load autoload_runtime.php if available in c3.php

### DIFF
--- a/c3.php
+++ b/c3.php
@@ -58,7 +58,11 @@ if (!class_exists('\\Codeception\\Codecept') || !function_exists('codecept_is_pa
     if (file_exists(__DIR__ . '/codecept.phar')) {
         require_once 'phar://' . __DIR__ . '/codecept.phar/autoload.php';
     } elseif (stream_resolve_include_path(__DIR__ . '/vendor/autoload.php')) {
-        require_once __DIR__ . '/vendor/autoload.php';
+        if (stream_resolve_include_path(__DIR__ . '/vendor/autoload_runtime.php')) {
+            require_once __DIR__ . '/vendor/autoload_runtime.php';
+        } else {
+            require_once __DIR__ . '/vendor/autoload.php';
+        }
         // Required to load some methods only available at codeception/autoload.php
         if (stream_resolve_include_path(__DIR__ . '/vendor/codeception/codeception/autoload.php')) {
             require_once __DIR__ . '/vendor/codeception/codeception/autoload.php';


### PR DESCRIPTION
Hello,

With Symfony 5.3, a new feature is available, the Runtime Component
[https://symfony.com/blog/new-in-symfony-5-3-runtime-component](https://symfony.com/blog/new-in-symfony-5-3-runtime-component)

This component generate an autoload_runtime.php which is load into the index.php instead of the autoload.php.

This PR add a condition into c3.php for load autoload_runtime.php instead of autoload.php if the file exist.