### PR TITLE
Fix headers already sent error

### DIFF
--- a/c3.php
+++ b/c3.php
@@ -48,8 +48,8 @@ if (!function_exists('__c3_error')) {
         }
         if (!headers_sent()) {
             header('X-Codeception-CodeCoverage-Error: ' . str_replace("\n", ' ', $message), true, 500);
+            setcookie('CODECEPTION_CODECOVERAGE_ERROR', $message);
         }
-        setcookie('CODECEPTION_CODECOVERAGE_ERROR', $message);
     }
 }
 


### PR DESCRIPTION
Fixes `<b>Fatal error</b>:  Uncaught ErrorException: Warning: Cannot modify header information - headers already sent in D:\Apps\Apache\DSCA\c3.php:52` reported in https://github.com/Codeception/Codeception/issues/6533